### PR TITLE
Make export conditional

### DIFF
--- a/src/zoned-date-time.js
+++ b/src/zoned-date-time.js
@@ -104,4 +104,6 @@ ZonedDateTime.prototype.toDate = function() {
   };
 });
 
-module.exports = ZonedDateTime;
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = ZonedDateTime;
+}


### PR DESCRIPTION
This package is used by Globalize and is loaded in a browser there using RequireJS, where it exports the `ZonedDateTime` global to be defined. So far so good.

This file is also assigning to `module.exports` which doesn't exist in the browser by default. So far, the Globalize tests were passing, but somewhat by accident. This statement didn't cause an error because Globalize uses QUnit 1.x which defines
a global function called  `module` as alias for the `QUnit.module()` method, and this code happens to work by adding an unexpected `exports` property to that function.

To unblock updating of Globalize, I propose updating this to do a minimal conditional export so that the code realiably works both in a browser and in Node.js.